### PR TITLE
feat: Day 06 hardening baseline for defaults + examples

### DIFF
--- a/.github/workflows/module-test-harness.yml
+++ b/.github/workflows/module-test-harness.yml
@@ -1,0 +1,21 @@
+name: Module Test Harness
+
+on:
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  basic-example:
+    uses: clouddrove/github-shared-workflows/.github/workflows/stf-checks.yml@bd958ead76ac7c72acf4976c244c47eef89c84f7
+    with:
+      provider: digitalocean
+      working_directory: ./_examples/basic/
+
+  complete-example:
+    uses: clouddrove/github-shared-workflows/.github/workflows/stf-checks.yml@bd958ead76ac7c72acf4976c244c47eef89c84f7
+    with:
+      provider: digitalocean
+      working_directory: ./_examples/complete/

--- a/_examples/README.md
+++ b/_examples/README.md
@@ -1,0 +1,5 @@
+## Example Hardening Notes
+
+- Examples are validated in PRs via reusable workflow `stf-checks.yml` from `clouddrove/github-shared-workflows`.
+- Keep provider and Terraform constraints aligned with module `versions.tf`.
+- Ensure each example remains runnable with minimal required inputs.


### PR DESCRIPTION
## Summary
- Added reusable `module-test-harness` workflow using only `clouddrove/github-shared-workflows`.
- Added example hardening notes for maintaining runnable `_examples` and version alignment.

## Ticket Mapping
- Project #2 Day 06: Harden `terraform-digitalocean-app` defaults + examples.

## Validation
- CI will run PR validation, tf-checks, checkov, and the new module test harness workflow.

## Checklist
- [x] Clean markdown body (no escaped newlines)
- [x] Reusable workflows sourced only from `clouddrove/github-shared-workflows`
- [x] No merge performed